### PR TITLE
replace call to deprecated available_attrs() to support Django 3

### DIFF
--- a/django_grip.py
+++ b/django_grip.py
@@ -2,10 +2,9 @@ from base64 import b64encode
 from struct import pack
 import threading
 import six
-from functools import wraps
+from functools import WRAPPER_ASSIGNMENTS, wraps
 from werkzeug.http import parse_options_header
 import django
-from django.utils.decorators import available_attrs
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest
 from pubcontrol import Item
@@ -200,7 +199,7 @@ def websocket_only(view_func):
 		return response
 
 	wrapped_view.websocket_only = True
-	return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
+	return wraps(view_func, assigned=WRAPPER_ASSIGNMENTS)(wrapped_view)
 
 class GripMiddleware(middleware_parent):
 	def process_request(self, request):


### PR DESCRIPTION
This PR adds support for Django 3.0.

`django.utils.decorators.available_attrs()` has been deprecated since Django 2.0 and removed in Django 3.0. (https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis). It has been replaced by `functools.WRAPPER_ASSIGNMENTS`.


Note: this may break compatibility with python 2, which is EOL and has been unsupported by Django since 2.0. If you accept this PR, you may also want to consider removing the compatibility library `six` as well.



