### PR TITLE
Update parse_options_header usage

### DIFF
--- a/django_grip.py
+++ b/django_grip.py
@@ -242,7 +242,7 @@ class GripMiddleware(middleware_parent):
 		# parse Grip-Feature
 		hvalue = request.META.get('HTTP_GRIP_FEATURE')
 		if hvalue:
-			parsed = parse_options_header(hvalue, multiple=True)
+			parsed = parse_options_header(hvalue)
 			features = set()
 			for n in range(0, len(parsed), 2):
 				features.add(parsed[n])
@@ -251,7 +251,7 @@ class GripMiddleware(middleware_parent):
 		# parse Grip-Last
 		hvalue = request.META.get('HTTP_GRIP_LAST')
 		if hvalue:
-			parsed = parse_options_header(hvalue, multiple=True)
+			parsed = parse_options_header(hvalue)
 
 			last = {}
 			for n in range(0, len(parsed), 2):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ author_email='justin@fanout.io',
 url='https://github.com/fanout/django-grip',
 license='MIT',
 py_modules=['django_grip'],
-install_requires=['Django>=1.9', 'pubcontrol>=3.0,<4', 'gripcontrol>=4.0,<5', 'Werkzeug>=1.0,<2.1', 'six>=1.10,<2'],
+install_requires=['Django>=1.9', 'pubcontrol>=3.0,<4', 'gripcontrol>=4.0,<5', 'Werkzeug>=1.0,<2.3', 'six>=1.10,<2'],
 classifiers=[
 	'Topic :: Utilities',
 	'License :: OSI Approved :: MIT License'

--- a/tests/middleware_tests.py
+++ b/tests/middleware_tests.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 import six
+import django
 from django.conf import settings
 from django.http import HttpResponse
 settings.configure()
@@ -9,13 +10,21 @@ sys.path.append('../')
 from gripcontrol import Channel
 from django_grip import GripMiddleware
 
+def dummy_get_response(request):
+	return None
+
+
 class MockRequest(object):
 	def __init__(self):
 		pass
 
 class TestMiddleware(unittest.TestCase):
 	def test_hold(self):
-		m = GripMiddleware()
+		if django.VERSION[0] >= 4:
+			m = GripMiddleware(dummy_get_response)
+		else:
+			m = GripMiddleware()
+
 
 		req = MockRequest()
 		req.method = 'GET'
@@ -43,7 +52,10 @@ class TestMiddleware(unittest.TestCase):
 		self.assertEqual(resp['Grip-Keep-Alive'], 'keepalive\\n; format=cstring; timeout=25')
 
 	def test_wscontext(self):
-		m = GripMiddleware()
+		if django.VERSION[0] >= 4:
+			m = GripMiddleware(dummy_get_response)
+		else:
+			m = GripMiddleware()
 
 		req = MockRequest()
 		req.method = 'GET'
@@ -80,7 +92,10 @@ class TestMiddleware(unittest.TestCase):
 		self.assertEqual(resp['Content-Type'], 'application/websocket-events')
 
 	def test_meta(self):
-		m = GripMiddleware()
+		if django.VERSION[0] >= 4:
+			m = GripMiddleware(dummy_get_response)
+		else:
+			m = GripMiddleware()
 
 		req = MockRequest()
 		req.method = 'POST'


### PR DESCRIPTION
The multiple parameter of parse_options_header has been deprecated in Werkzeug as of 2.1.0.  It was not really doing anything inside Werkzeug

Updated Werzeug requirement to require <2.3

Updated tests for Django 4.0