### PR TITLE
Update parse_options_header usage for multiple mime type and options

### DIFF
--- a/django_grip.py
+++ b/django_grip.py
@@ -250,21 +250,17 @@ class GripMiddleware(middleware_parent):
 		# parse Grip-Feature
 		hvalue = request.META.get('HTTP_GRIP_FEATURE')
 		if hvalue:
-			parsed = parse_options_header(hvalue)
+			parsed = hvalue.split(", ")
 			features = set()
-			for n in range(0, len(parsed), 2):
-				features.add(parsed[n])
+			features.update(parsed)
 			request.grip.features = features
 
 		# parse Grip-Last
 		hvalue = request.META.get('HTTP_GRIP_LAST')
 		if hvalue:
-			parsed = parse_options_header(hvalue)
-
 			last = {}
-			for n in range(0, len(parsed), 2):
-				channel = parsed[n]
-				params = parsed[n + 1]
+			for hval in hvalue.split(","):
+				channel, params = parse_options_header(hval)
 				last[channel] = params.get('last-id', '')
 
 			request.grip.last = last


### PR DESCRIPTION
According to Pull #16 The multiple parameter of parse_options_header has been deprecated in Werkzeug as of 2.1.0. But pushpin still send multiple `MIME types` and `options` such as `'HTTP_GRIP_LAST': 'events-room-1; last-id=3,events-room-2; last-id=4'` -> `results` = `('events-room-1', {'last-id':4})` which cause malfunctions.
**Changes**
- For `HTTP_GRIP_FEATURE`
  - Split manually with `.split(', ')`
- For `HTTP_GRIP_LAST`
  - Split hvalue with `.split(',')` before parse each
