### PR TITLE
Fix: description file naming to underscore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
 setup tools wants underscore instead of dashes, let's update please, it causes breaking errors for other dependencies that use this such as `django-eventstream`     


```      
 setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.

hint: This usually indicates a problem with the package or the build environment.
```